### PR TITLE
Adding support for multi-value profiling using filterin and filterout elements

### DIFF
--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -155,57 +155,57 @@
     </xsl:variable>
 
     <xsl:choose>
-      <xsl:when test="$effectivity.match.arch != ''">
+      <xsl:when test="$effectivity.match.arch = '1'">
         <xsl:text>exclude</xsl:text>        
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.audience != ''">
+      <xsl:when test="$effectivity.match.audience = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.condition != ''">
+      <xsl:when test="$effectivity.match.condition = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.conformance != ''">
+      <xsl:when test="$effectivity.match.conformance = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.os != ''">
+      <xsl:when test="$effectivity.match.os = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.outputformat != ''">
+      <xsl:when test="$effectivity.match.outputformat = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.revision != ''">
+      <xsl:when test="$effectivity.match.revision = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.security != ''">
+      <xsl:when test="$effectivity.match.security = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.userlevel != ''">
+      <xsl:when test="$effectivity.match.userlevel = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.vendor != ''">
+      <xsl:when test="$effectivity.match.vendor = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.wordsize != ''">
+      <xsl:when test="$effectivity.match.wordsize = '1'">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
       </xsl:when>
@@ -320,57 +320,57 @@
     </xsl:variable>
 
     <xsl:choose>
-      <xsl:when test="$effectivity.match.arch != ''">
+      <xsl:when test="$effectivity.match.arch = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.audience != ''">
+      <xsl:when test="$effectivity.match.audience = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.condition != ''">
+      <xsl:when test="$effectivity.match.condition = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.conformance != ''">
+      <xsl:when test="$effectivity.match.conformance = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.os != ''">
+      <xsl:when test="$effectivity.match.os = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.outputformat != ''">
+      <xsl:when test="$effectivity.match.outputformat = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.revision != ''">
+      <xsl:when test="$effectivity.match.revision = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.security != ''">
+      <xsl:when test="$effectivity.match.security = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.userlevel != ''">
+      <xsl:when test="$effectivity.match.userlevel = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.vendor != ''">
+      <xsl:when test="$effectivity.match.vendor = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.match.wordsize != ''">
+      <xsl:when test="$effectivity.match.wordsize = '1'">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
       </xsl:when>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -24,7 +24,9 @@
   <xsl:param name="effectivity.userlevel" />
   <xsl:param name="effectivity.vendor" />
   <xsl:param name="effectivity.wordsize" />
-  <xsl:param name="effectivity.separator" />
+  <xsl:param name="effectivity.separator">;</xsl:param> 
+  <!-- NOTE: The separator param is set to ; by default; this is ensure the conditional processing will work even if user does not pass in a 
+  separator -->
 
   <xsl:param name="profile.arch" select="$effectivity.arch"/>
   <xsl:param name="profile.audience" select="$effectivity.audience"/>
@@ -56,100 +58,127 @@
     <xsl:variable name="effectivity.match.arch">
       <!-- <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
       <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
+    <xsl:if test="@arch">  
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.arch" />
         <xsl:with-param name="b" select="@arch" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-      <!-- <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message> -->
+      <!-- <xsl:if test="effectivity.audience">
+        <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+        <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
+      </xsl:if> -->
+    <xsl:if test="@audience">
+      <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.audience" />
         <xsl:with-param name="b" select="@audience" />
+        <xsl:with-param name="sep" select="effectivity.separator" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
       <!-- <xsl:message>INFO: The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
       <xsl:message>INFO: The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
+    <xsl:if test="@condition">  
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.condition" />
         <xsl:with-param name="b" select="@condition" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
       <!-- <xsl:message>INFO: The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
       <xsl:message>INFO: The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
+    <xsl:if test="@conformance">  
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.conformance" />
         <xsl:with-param name="b" select="@conformance" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
       <!-- <xsl:message>INFO: The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
       <xsl:message>INFO: The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
+    <xsl:if test="@os">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.os" />
         <xsl:with-param name="b" select="@os" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <!-- <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
+      <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+    <xsl:if test="@outputformat">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.outputformat" />
         <xsl:with-param name="b" select="@outputformat" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
       <!-- <xsl:message>INFO: The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
       <xsl:message>INFO: The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
+    <xsl:if test="@revision">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.revision" />
         <xsl:with-param name="b" select="@revision" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
       <!-- <xsl:message>INFO: The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
       <xsl:message>INFO: The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
+    <xsl:if test="@security">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.security" />
         <xsl:with-param name="b" select="@security" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
       <!-- <xsl:message>INFO: The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
       <xsl:message>INFO: The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
+      <xsl:if test="@userlevel">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.userlevel" />
         <xsl:with-param name="b" select="@userlevel" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
       <!-- <xsl:message>INFO: The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
       <xsl:message>INFO: The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
+    <xsl:if test="@vendor">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.vendor" />
         <xsl:with-param name="b" select="@vendor" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
       <!-- <xsl:message>INFO: The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
       <xsl:message>INFO: The value of @wordize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
+    <xsl:if test="@wordsize">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.wordsize" />
         <xsl:with-param name="b" select="@wordsize" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:choose>
@@ -221,100 +250,122 @@
     <xsl:variable name="effectivity.match.arch">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
+    <xsl:if test="@arch">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.arch" />
         <xsl:with-param name="b" select="@arch" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
        <!-- <xsl:message>INFO (filterin): The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message> -->
+    <xsl:if test="@audience">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.audience" />
         <xsl:with-param name="b" select="@audience" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
        <!-- <xsl:message>INFO (filterin): The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
+    <xsl:if test="@condition">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.condition" />
         <xsl:with-param name="b" select="@condition" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
        <!-- <xsl:message>INFO (filterin): The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
+    <xsl:if test="@conformance">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.conformance" />
         <xsl:with-param name="b" select="@conformance" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
+      <xsl:if test="@os">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.os" />
         <xsl:with-param name="b" select="@os" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
+    <xsl:if test="@outputformat">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.outputformat" />
         <xsl:with-param name="b" select="@outputformat" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
        <!-- <xsl:message>INFO (filterin): The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
+    <xsl:if test="@revision">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.revision" />
         <xsl:with-param name="b" select="@revision" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
        <!-- <xsl:message>INFO (filterin): The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
+    <xsl:if test="@security">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.security" />
         <xsl:with-param name="b" select="@security" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
+    <xsl:if test="@userlevel">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.userlevel" />
         <xsl:with-param name="b" select="@userlevel" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
+    <xsl:if test="@vendor">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.vendor" />
         <xsl:with-param name="b" select="@vendor" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @wordsize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
+    <xsl:if test="@wordsize">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.wordsize" />
         <xsl:with-param name="b" select="@wordsize" />
       </xsl:call-template>
+    </xsl:if>
     </xsl:variable>
 
     <xsl:choose>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -24,7 +24,7 @@
   <xsl:param name="effectivity.userlevel" />
   <xsl:param name="effectivity.vendor" />
   <xsl:param name="effectivity.wordsize" />
-  <xsl:param name="effectivity.separator"/>
+  <xsl:param name="effectivity.separator">;</xsl:param>
 
 
   <xsl:param name="profile.arch" select="$effectivity.arch"/>
@@ -44,7 +44,7 @@
   <xsl:param name="profile.status"/>
   <xsl:param name="profile.attribute"/>
   <xsl:param name="profile.value"/>
-  <xsl:param name="profile.separator" select="';'" />
+  <xsl:param name="profile.separator" select="$effectivity.separator" />
 <!-- NOTE: The separator param is set to ; by default; this is ensure the conditional processing will work even if user does not pass in a 
   separator -->
 
@@ -56,7 +56,7 @@
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
 
     <xsl:variable name="effectivity.match.arch">
-      <xsl:if test="@arch">  
+      <xsl:if test="@arch and string-length($effectivity.arch) &gt; 0">  
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.arch" />
           <xsl:with-param name="b" select="@arch" />
@@ -65,7 +65,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-      <xsl:if test="@audience">
+      <xsl:if test="@audience and string-length($effectivity.audience) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.audience" />
           <xsl:with-param name="b" select="@audience" />
@@ -74,7 +74,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
-      <xsl:if test="@condition">  
+      <xsl:if test="@condition and string-length($effectivity.condition) &gt; 0">  
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.condition" />
           <xsl:with-param name="b" select="@condition" />
@@ -83,7 +83,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
-      <xsl:if test="@conformance">  
+      <xsl:if test="@conformance and string-length($effectivity.conformance) &gt; 0">  
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.conformance" />
           <xsl:with-param name="b" select="@conformance" />
@@ -92,7 +92,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
-      <xsl:if test="@os">
+      <xsl:if test="@os and string-length($effectivity.os) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.os" />
           <xsl:with-param name="b" select="@os" />
@@ -101,7 +101,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <xsl:if test="@outputformat">
+      <xsl:if test="@outputformat and string-length($effectivity.outputformat) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.outputformat" />
           <xsl:with-param name="b" select="@outputformat" />
@@ -110,7 +110,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
-      <xsl:if test="@revision">
+      <xsl:if test="@revision and string-length($effectivity.revision) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.revision" />
           <xsl:with-param name="b" select="@revision" />
@@ -119,7 +119,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
-      <xsl:if test="@security">
+      <xsl:if test="@security and string-length($effectivity.security) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.security" />
           <xsl:with-param name="b" select="@security" />
@@ -128,7 +128,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
-      <xsl:if test="@userlevel">
+      <xsl:if test="@userlevel and string-length($effectivity.userlevel) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.userlevel" />
           <xsl:with-param name="b" select="@userlevel" />
@@ -137,7 +137,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
-      <xsl:if test="@vendor">
+      <xsl:if test="@vendor and string-length($effectivity.vendor) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.vendor" />
           <xsl:with-param name="b" select="@vendor" />
@@ -146,7 +146,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
-      <xsl:if test="@wordsize">
+      <xsl:if test="@wordsize and string-length($effectivity.wordsize) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.wordsize" />
           <xsl:with-param name="b" select="@wordsize" />
@@ -221,7 +221,7 @@
   <xsl:template match="d:filterin" mode="evaluate.effectivity">
 
     <xsl:variable name="effectivity.match.arch">
-      <xsl:if test="@arch">
+      <xsl:if test="@arch and string-length($effectivity.arch) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.arch" />
           <xsl:with-param name="b" select="@arch" />
@@ -230,7 +230,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-      <xsl:if test="@audience">
+      <xsl:if test="@audience and string-length($effectivity.audience) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.audience" />
           <xsl:with-param name="b" select="@audience" />
@@ -239,7 +239,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
-      <xsl:if test="@condition">
+      <xsl:if test="@condition and string-length($effectivity.condition) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.condition" />
           <xsl:with-param name="b" select="@condition" />
@@ -248,7 +248,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
-      <xsl:if test="@conformance">
+      <xsl:if test="@conformance and string-length($effectivity.conformance) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.conformance" />
           <xsl:with-param name="b" select="@conformance" />
@@ -257,7 +257,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
-      <xsl:if test="@os">
+      <xsl:if test="@os and string-length($effectivity.os) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.os" />
           <xsl:with-param name="b" select="@os" />
@@ -266,7 +266,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <xsl:if test="@outputformat">
+      <xsl:if test="@outputformat and string-length($effectivity.outputformat) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.outputformat" />
           <xsl:with-param name="b" select="@outputformat" />
@@ -275,7 +275,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
-      <xsl:if test="@revision">
+      <xsl:if test="@revision and string-length($effectivity.revision) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.revision" />
           <xsl:with-param name="b" select="@revision" />
@@ -284,16 +284,16 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
-      <xsl:if test="@security">
+      <xsl:if test="@security and string-length($effectivity.security) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.security" />
           <xsl:with-param name="b" select="@security" />
         </xsl:call-template>
       </xsl:if>
     </xsl:variable>
-
+    
     <xsl:variable name="effectivity.match.userlevel">
-      <xsl:if test="@userlevel">
+      <xsl:if test="@userlevel and string-length($effectivity.userlevel) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.userlevel" />
           <xsl:with-param name="b" select="@userlevel" />
@@ -302,7 +302,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
-      <xsl:if test="@vendor">
+      <xsl:if test="@vendor and string-length($effectivity.vendor) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.vendor" />
           <xsl:with-param name="b" select="@vendor" />
@@ -311,7 +311,7 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
-      <xsl:if test="@wordsize">
+      <xsl:if test="@wordsize and string-length($effectivity.wordsize) &gt; 0">
         <xsl:call-template name="cross.compare">
           <xsl:with-param name="a" select="$effectivity.wordsize" />
           <xsl:with-param name="b" select="@wordsize" />

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -52,21 +52,19 @@
   </xsl:template>
   
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
-    <xsl:message>INFO: I'm inside the filterout template!</xsl:message>
     
     <xsl:variable name="effectivity.match.arch">
-      <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message>
+      <!-- <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.arch" />
         <xsl:with-param name="b" select="@arch" />
       </xsl:call-template>
     </xsl:variable>
-    <xsl:message>INFO: The value of effectivity.match.arch is <xsl:value-of select="$effectivity.match.arch"/> ... </xsl:message>
 
     <xsl:variable name="effectivity.match.audience">
-      <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
+      <!-- <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.audience" />
         <xsl:with-param name="b" select="@audience" />
@@ -155,8 +153,6 @@
     </xsl:variable>
 
     <xsl:choose>
-      <!-- <xsl:when test="$effectivity.attribute.arch = $effectivity.arch"> -->
-      <!-- <xsl:when test="effectivity.match.arch != '' "> -->
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>        
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
@@ -164,52 +160,52 @@
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.match.condition" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.match.conformance" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.match.os" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.match.outputformat" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.match.revision" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.match.security" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.match.userlevel" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.match.vendor" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.match.wordsize" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>
@@ -221,7 +217,6 @@
   
   <!-- filterin logic -->
   <xsl:template match="d:filterin" mode="evaluate.effectivity">
-    <xsl:message>INFO: I'm inside the filterin template!</xsl:message>
 
     <xsl:variable name="effectivity.match.arch">
       <!-- <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
@@ -269,8 +264,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.outputformat" />
         <xsl:with-param name="b" select="@outputformat" />
@@ -325,57 +320,57 @@
     <xsl:choose>
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
+        <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.match.condition" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.match.conformance" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.match.os" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.match.outputformat" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.match.revision" />.</xsl:message> 
+        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message> 
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.match.security" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.match.userlevel" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.match.vendor" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.match.wordsize" />.</xsl:message>
+        <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -73,81 +73,81 @@
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.condition">
-      <xsl:message>INFO: The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.condition">
+      <!-- <xsl:message>INFO: The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.condition" />
         <xsl:with-param name="b" select="@condition" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.conformance">
-      <xsl:message>INFO: The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.conformance">
+      <!-- <xsl:message>INFO: The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.conformance" />
         <xsl:with-param name="b" select="@conformance" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.os">
-      <xsl:message>INFO: The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.os">
+      <!-- <xsl:message>INFO: The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.os" />
         <xsl:with-param name="b" select="@os" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.outputformat">
-      <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.outputformat">
+      <!-- <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.outputformat" />
         <xsl:with-param name="b" select="@outputformat" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.revision">
-      <xsl:message>INFO: The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.revision">
+      <!-- <xsl:message>INFO: The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.revision" />
         <xsl:with-param name="b" select="@revision" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.security">
-      <xsl:message>INFO: The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.security">
+      <!-- <xsl:message>INFO: The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.security" />
         <xsl:with-param name="b" select="@security" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.userlevel">
-      <xsl:message>INFO: The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.userlevel">
+      <!-- <xsl:message>INFO: The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.userlevel" />
         <xsl:with-param name="b" select="@userlevel" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.vendor">
-      <xsl:message>INFO: The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.vendor">
+      <!-- <xsl:message>INFO: The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.vendor" />
         <xsl:with-param name="b" select="@vendor" />
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.wordsize">
-      <xsl:message>INFO: The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @wordize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message>
+    <xsl:variable name="effectivity.match.wordsize">
+      <!-- <xsl:message>INFO: The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @wordize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.wordsize" />
         <xsl:with-param name="b" select="@wordsize" />
@@ -159,7 +159,7 @@
       <!-- <xsl:when test="effectivity.match.arch != '' "> -->
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>        
-        <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
@@ -224,8 +224,8 @@
     <xsl:message>INFO: I'm inside the filterin template!</xsl:message>
 
     <xsl:variable name="effectivity.match.arch">
-      <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.arch" />
         <xsl:with-param name="b" select="@arch" />
@@ -233,8 +233,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-       <xsl:message>INFO (filterin): The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
+       <!-- <xsl:message>INFO (filterin): The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.audience" />
         <xsl:with-param name="b" select="@audience" />
@@ -242,8 +242,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
-       <xsl:message>INFO (filterin): The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message>
+       <!-- <xsl:message>INFO (filterin): The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.condition" />
         <xsl:with-param name="b" select="@condition" />
@@ -251,8 +251,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
-       <xsl:message>INFO (filterin): The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message>
+       <!-- <xsl:message>INFO (filterin): The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.conformance" />
         <xsl:with-param name="b" select="@conformance" />
@@ -260,8 +260,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
-       <xsl:message>INFO (filterin): The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.os" />
         <xsl:with-param name="b" select="@os" />
@@ -278,8 +278,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
-       <xsl:message>INFO (filterin): The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message>
+       <!-- <xsl:message>INFO (filterin): The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.revision" />
         <xsl:with-param name="b" select="@revision" />
@@ -287,8 +287,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
-       <xsl:message>INFO (filterin): The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message>
+       <!-- <xsl:message>INFO (filterin): The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.security" />
         <xsl:with-param name="b" select="@security" />
@@ -296,8 +296,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
-      <xsl:message>INFO (filterin): The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.userlevel" />
         <xsl:with-param name="b" select="@userlevel" />
@@ -305,8 +305,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
-      <xsl:message>INFO (filterin): The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.vendor" />
         <xsl:with-param name="b" select="@vendor" />
@@ -314,8 +314,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
-      <xsl:message>INFO (filterin): The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @wordsize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message>
+      <!-- <xsl:message>INFO (filterin): The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @wordsize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.wordsize" />
         <xsl:with-param name="b" select="@wordsize" />
@@ -325,7 +325,7 @@
     <xsl:choose>
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
+        <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
@@ -386,33 +386,5 @@
     </xsl:choose>
 
   </xsl:template>
-
-
-  <!-- Returns non-empty string if list in $b contains one ore more values from list $a --> 
- <!-- Commenting out the copied cross.compare template 
-<xsl:template name="cross.compare">
-
-  <xsl:param name="a"/>
-  <xsl:param name="b"/>
-  <xsl:param name="sep" select="$profile.separator"/>
-  <xsl:variable name="head" select="substring-before(concat($a, $sep), $sep)"/>
-  <xsl:variable name="tail" select="substring-after($a, $sep)"/> 
--->
-<!-- <xsl:message> -->
-<!-- a="<xsl:value-of select="$a"/>" -->
-<!-- a="<xsl:value-of select="normalize-space($a)"/>" -->
-<!-- head="<xsl:value-of select="$head"/>" -->
-<!-- tail="<xsl:value-of select="$tail"/>" -->
-<!-- </xsl:message> -->
-<!--
-  <xsl:message>INFO: My profile separator character is <xsl:value-of select="$profile.separator"/> ...</xsl:message>
-  <xsl:if test="contains(concat($sep, $b, $sep), concat($sep, $head, $sep)) or normalize-space($a) = '' ">1</xsl:if>
-  <xsl:if test="$tail">
-    <xsl:call-template name="cross.compare">
-      <xsl:with-param name="a" select="$tail"/>
-      <xsl:with-param name="b" select="$b"/>
-    </xsl:call-template>
-  </xsl:if>
-</xsl:template> -->
 
 </xsl:stylesheet>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -24,7 +24,8 @@
   <xsl:param name="effectivity.userlevel" />
   <xsl:param name="effectivity.vendor" />
   <xsl:param name="effectivity.wordsize" />
-  <xsl:param name="effectivity.separator">;</xsl:param> 
+  <xsl:param name="effectivity.separator"/>
+
   <!-- NOTE: The separator param is set to ; by default; this is ensure the conditional processing will work even if user does not pass in a 
   separator -->
 
@@ -45,7 +46,7 @@
   <xsl:param name="profile.status"/>
   <xsl:param name="profile.attribute"/>
   <xsl:param name="profile.value"/>
-  <xsl:param name="profile.separator" select="$effectivity.separator" />
+  <xsl:param name="profile.separator" select="';'" />
 
 
 
@@ -54,7 +55,7 @@
   </xsl:template>
   
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
-    
+
     <xsl:variable name="effectivity.match.arch">
       <!-- <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
       <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
@@ -72,12 +73,10 @@
         <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
       </xsl:if> -->
     <xsl:if test="@audience">
-      <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.audience" />
         <xsl:with-param name="b" select="@audience" />
-        <xsl:with-param name="sep" select="effectivity.separator" />
+        <!-- <xsl:with-param name="sep" select="$effectivity.separator" /> -->
       </xsl:call-template>
     </xsl:if>
     </xsl:variable>
@@ -116,8 +115,8 @@
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+      <!-- <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
     <xsl:if test="@outputformat">
       <xsl:call-template name="cross.compare">
         <xsl:with-param name="a" select="$effectivity.outputformat" />
@@ -185,56 +184,67 @@
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>        
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>
@@ -372,56 +382,67 @@
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>include</xsl:text>
-        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message> 
+        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
+        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -26,8 +26,6 @@
   <xsl:param name="effectivity.wordsize" />
   <xsl:param name="effectivity.separator"/>
 
-  <!-- NOTE: The separator param is set to ; by default; this is ensure the conditional processing will work even if user does not pass in a 
-  separator -->
 
   <xsl:param name="profile.arch" select="$effectivity.arch"/>
   <xsl:param name="profile.audience" select="$effectivity.audience"/>
@@ -47,7 +45,8 @@
   <xsl:param name="profile.attribute"/>
   <xsl:param name="profile.value"/>
   <xsl:param name="profile.separator" select="';'" />
-
+<!-- NOTE: The separator param is set to ; by default; this is ensure the conditional processing will work even if user does not pass in a 
+  separator -->
 
 
   <xsl:template match="d:module[@resourceref] | d:structure[@resourceref]" mode="evaluate.effectivity">
@@ -57,194 +56,158 @@
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
 
     <xsl:variable name="effectivity.match.arch">
-      <!-- <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
-    <xsl:if test="@arch">  
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.arch" />
-        <xsl:with-param name="b" select="@arch" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@arch">  
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.arch" />
+          <xsl:with-param name="b" select="@arch" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-      <!-- <xsl:if test="effectivity.audience">
-        <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-        <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
-      </xsl:if> -->
-    <xsl:if test="@audience">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.audience" />
-        <xsl:with-param name="b" select="@audience" />
-        <!-- <xsl:with-param name="sep" select="$effectivity.separator" /> -->
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@audience">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.audience" />
+          <xsl:with-param name="b" select="@audience" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
-      <!-- <xsl:message>INFO: The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
-    <xsl:if test="@condition">  
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.condition" />
-        <xsl:with-param name="b" select="@condition" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@condition">  
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.condition" />
+          <xsl:with-param name="b" select="@condition" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
-      <!-- <xsl:message>INFO: The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
-    <xsl:if test="@conformance">  
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.conformance" />
-        <xsl:with-param name="b" select="@conformance" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@conformance">  
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.conformance" />
+          <xsl:with-param name="b" select="@conformance" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
-      <!-- <xsl:message>INFO: The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
-    <xsl:if test="@os">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.os" />
-        <xsl:with-param name="b" select="@os" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@os">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.os" />
+          <xsl:with-param name="b" select="@os" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <!-- <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
-    <xsl:if test="@outputformat">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.outputformat" />
-        <xsl:with-param name="b" select="@outputformat" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@outputformat">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.outputformat" />
+          <xsl:with-param name="b" select="@outputformat" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
-      <!-- <xsl:message>INFO: The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
-    <xsl:if test="@revision">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.revision" />
-        <xsl:with-param name="b" select="@revision" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@revision">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.revision" />
+          <xsl:with-param name="b" select="@revision" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
-      <!-- <xsl:message>INFO: The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
-    <xsl:if test="@security">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.security" />
-        <xsl:with-param name="b" select="@security" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@security">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.security" />
+          <xsl:with-param name="b" select="@security" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
-      <!-- <xsl:message>INFO: The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
       <xsl:if test="@userlevel">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.userlevel" />
-        <xsl:with-param name="b" select="@userlevel" />
-      </xsl:call-template>
-    </xsl:if>
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.userlevel" />
+          <xsl:with-param name="b" select="@userlevel" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
-      <!-- <xsl:message>INFO: The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
-    <xsl:if test="@vendor">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.vendor" />
-        <xsl:with-param name="b" select="@vendor" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@vendor">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.vendor" />
+          <xsl:with-param name="b" select="@vendor" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
-      <!-- <xsl:message>INFO: The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
-      <xsl:message>INFO: The value of @wordize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
-    <xsl:if test="@wordsize">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.wordsize" />
-        <xsl:with-param name="b" select="@wordsize" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@wordsize">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.wordsize" />
+          <xsl:with-param name="b" select="@wordsize" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:choose>
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>        
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>exclude</xsl:text>
         <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>
@@ -258,196 +221,163 @@
   <xsl:template match="d:filterin" mode="evaluate.effectivity">
 
     <xsl:variable name="effectivity.match.arch">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message> -->
-    <xsl:if test="@arch">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.arch" />
-        <xsl:with-param name="b" select="@arch" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@arch">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.arch" />
+          <xsl:with-param name="b" select="@arch" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.audience">
-       <!-- <xsl:message>INFO (filterin): The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message> -->
-    <xsl:if test="@audience">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.audience" />
-        <xsl:with-param name="b" select="@audience" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@audience">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.audience" />
+          <xsl:with-param name="b" select="@audience" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.condition">
-       <!-- <xsl:message>INFO (filterin): The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message> -->
-    <xsl:if test="@condition">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.condition" />
-        <xsl:with-param name="b" select="@condition" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@condition">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.condition" />
+          <xsl:with-param name="b" select="@condition" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.conformance">
-       <!-- <xsl:message>INFO (filterin): The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message> -->
-    <xsl:if test="@conformance">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.conformance" />
-        <xsl:with-param name="b" select="@conformance" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@conformance">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.conformance" />
+          <xsl:with-param name="b" select="@conformance" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.os">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message> -->
       <xsl:if test="@os">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.os" />
-        <xsl:with-param name="b" select="@os" />
-      </xsl:call-template>
-    </xsl:if>
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.os" />
+          <xsl:with-param name="b" select="@os" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.outputformat">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message> -->
-    <xsl:if test="@outputformat">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.outputformat" />
-        <xsl:with-param name="b" select="@outputformat" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@outputformat">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.outputformat" />
+          <xsl:with-param name="b" select="@outputformat" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.revision">
-       <!-- <xsl:message>INFO (filterin): The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message> -->
-    <xsl:if test="@revision">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.revision" />
-        <xsl:with-param name="b" select="@revision" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@revision">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.revision" />
+          <xsl:with-param name="b" select="@revision" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.security">
-       <!-- <xsl:message>INFO (filterin): The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message> -->
-    <xsl:if test="@security">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.security" />
-        <xsl:with-param name="b" select="@security" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@security">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.security" />
+          <xsl:with-param name="b" select="@security" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.userlevel">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message> -->
-    <xsl:if test="@userlevel">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.userlevel" />
-        <xsl:with-param name="b" select="@userlevel" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@userlevel">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.userlevel" />
+          <xsl:with-param name="b" select="@userlevel" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.vendor">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message> -->
-    <xsl:if test="@vendor">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.vendor" />
-        <xsl:with-param name="b" select="@vendor" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@vendor">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.vendor" />
+          <xsl:with-param name="b" select="@vendor" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:variable name="effectivity.match.wordsize">
-      <!-- <xsl:message>INFO (filterin): The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
-      <xsl:message>INFO (filterin): The value of @wordsize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message> -->
-    <xsl:if test="@wordsize">
-      <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="$effectivity.wordsize" />
-        <xsl:with-param name="b" select="@wordsize" />
-      </xsl:call-template>
-    </xsl:if>
+      <xsl:if test="@wordsize">
+        <xsl:call-template name="cross.compare">
+          <xsl:with-param name="a" select="$effectivity.wordsize" />
+          <xsl:with-param name="b" select="@wordsize" />
+        </xsl:call-template>
+      </xsl:if>
     </xsl:variable>
 
     <xsl:choose>
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO (filterin): including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.arch" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.audience" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.condition" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.conformance" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.os" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.outputformat" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.revision" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.security" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.userlevel" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.vendor" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>include</xsl:text>
         <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.wordsize" />.</xsl:message>
-        <xsl:message>========</xsl:message>
       </xsl:when>
 
       <xsl:otherwise>
         <xsl:text>exclude</xsl:text>
-        <!-- <xsl:message>INFO: No modules or structures matched attributes for inclusion.</xsl:message> -->
+        <xsl:message>INFO: No modules or structures matched attributes for inclusion.</xsl:message>
       </xsl:otherwise>
 
     </xsl:choose>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -72,76 +72,146 @@
         <xsl:with-param name="b" select="@audience" />
       </xsl:call-template>
     </xsl:variable>
-    <xsl:variable name="effectivity.attribute.condition" select="@condition" />
-    <xsl:variable name="effectivity.attribute.conformance" select="@conformance" />
-    <xsl:variable name="effectivity.attribute.os" select="@os" />
-    <xsl:variable name="effectivity.attribute.outputformat" select="@outputformat" />
-    <xsl:variable name="effectivity.attribute.revision" select="@revision" />
-    <xsl:variable name="effectivity.attribute.security" select="@security" />
-    <xsl:variable name="effectivity.attribute.userlevel" select="@userlevel" />
-    <xsl:variable name="effectivity.attribute.vendor" select="@vendor" />
-    <xsl:variable name="effectivity.attribute.wordsize" select="@wordsize" />
+
+    <xsl:variable name="effectivity.attribute.condition">
+      <xsl:message>INFO: The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.condition" />
+        <xsl:with-param name="b" select="@condition" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.conformance">
+      <xsl:message>INFO: The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.conformance" />
+        <xsl:with-param name="b" select="@conformance" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.os">
+      <xsl:message>INFO: The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.os" />
+        <xsl:with-param name="b" select="@os" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.outputformat">
+      <xsl:message>INFO: The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.outputformat" />
+        <xsl:with-param name="b" select="@outputformat" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.revision">
+      <xsl:message>INFO: The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.revision" />
+        <xsl:with-param name="b" select="@revision" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.security">
+      <xsl:message>INFO: The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.security" />
+        <xsl:with-param name="b" select="@security" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.userlevel">
+      <xsl:message>INFO: The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.userlevel" />
+        <xsl:with-param name="b" select="@userlevel" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.vendor">
+      <xsl:message>INFO: The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.vendor" />
+        <xsl:with-param name="b" select="@vendor" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.attribute.wordsize">
+      <xsl:message>INFO: The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @wordize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.wordsize" />
+        <xsl:with-param name="b" select="@wordsize" />
+      </xsl:call-template>
+    </xsl:variable>
 
     <xsl:choose>
       <!-- <xsl:when test="$effectivity.attribute.arch = $effectivity.arch"> -->
       <!-- <xsl:when test="effectivity.match.arch != '' "> -->
       <xsl:when test="$effectivity.match.arch != ''">
-        <xsl:text>exclude</xsl:text>
-        
+        <xsl:text>exclude</xsl:text>        
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
       </xsl:when>
 
       <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>exclude</xsl:text>
-        
-        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message>
       </xsl:when>
 
-      <xsl:when test="$effectivity.attribute.condition = $effectivity.condition">
+      <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.attribute.condition" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.match.condition" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.conformance = $effectivity.conformance">
+
+      <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.attribute.conformance" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.match.conformance" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.os = $effectivity.os">
+
+      <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.attribute.os" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.match.os" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.outputformat = $effectivity.outputformat">
+
+      <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.attribute.outputformat" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.match.outputformat" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.revision = $effectivity.revision">
+
+      <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.attribute.revision" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.match.revision" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.security = $effectivity.security">
+
+      <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.attribute.security" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.match.security" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.userlevel = $effectivity.userlevel">
+
+      <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.attribute.userlevel" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.match.userlevel" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.vendor = $effectivity.vendor">
+
+      <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.attribute.vendor" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.match.vendor" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.wordsize = $effectivity.wordsize">
+
+      <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.attribute.wordsize" />.</xsl:message> -->
+        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.attribute.wordsize" />.</xsl:message>
       </xsl:when>
+      
       <xsl:otherwise>
         <xsl:message>INFO: no filterout attributes matched.</xsl:message>
       </xsl:otherwise>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -27,20 +27,26 @@
   </xsl:template>
   
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
-    <xsl:variable name="effectivity.attribute.arch" select="@arch" />
-    <xsl:variable name="effectivity.attribute.audience" select="@audience" />
-    <xsl:variable name="effectivity.attribute.condition" select="@condition" />
-    <xsl:variable name="effectivity.attribute.conformance" select="@conformance" />
-    <xsl:variable name="effectivity.attribute.os" select="@os" />
-    <xsl:variable name="effectivity.attribute.outputformat" select="@outputformat" />
-    <xsl:variable name="effectivity.attribute.revision" select="@revision" />
-    <xsl:variable name="effectivity.attribute.security" select="@security" />
-    <xsl:variable name="effectivity.attribute.userlevel" select="@userlevel" />
-    <xsl:variable name="effectivity.attribute.vendor" select="@vendor" />
-    <xsl:variable name="effectivity.attribute.wordsize" select="@wordsize" />
+    <xsl:variable name="effectivity.match.arch">
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="effectivity.arch" />
+        <xsl:with-param name="b" select="@arch" />
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="effectivity.match.audience" select="@audience" />
+    <xsl:variable name="effectivity.match.condition" select="@condition" />
+    <xsl:variable name="effectivity.match.conformance" select="@conformance" />
+    <xsl:variable name="effectivity.match.os" select="@os" />
+    <xsl:variable name="effectivity.match.outputformat" select="@outputformat" />
+    <xsl:variable name="effectivity.match.revision" select="@revision" />
+    <xsl:variable name="effectivity.match.security" select="@security" />
+    <xsl:variable name="effectivity.match.userlevel" select="@userlevel" />
+    <xsl:variable name="effectivity.match.vendor" select="@vendor" />
+    <xsl:variable name="effectivity.match.wordsize" select="@wordsize" />
 
     <xsl:choose>
-      <xsl:when test="$effectivity.attribute.arch = $effectivity.arch">
+      <!-- <xsl:when test="$effectivity.attribute.arch = $effectivity.arch"> -->
+      <xsl:when test="effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>
         <!--
         <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.attribute.arch" />.</xsl:message> -->

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -209,9 +209,9 @@
 
       <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>exclude</xsl:text>
-        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.attribute.wordsize" />.</xsl:message>
+        <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.match.wordsize" />.</xsl:message>
       </xsl:when>
-      
+
       <xsl:otherwise>
         <xsl:message>INFO: no filterout attributes matched.</xsl:message>
       </xsl:otherwise>
@@ -221,7 +221,7 @@
   
   <!-- filterin logic -->
   <xsl:template match="d:filterin" mode="evaluate.effectivity">
-    <xsl:message>INFO: I'm inside the filterout template!</xsl:message>
+    <xsl:message>INFO: I'm inside the filterin template!</xsl:message>
 
     <xsl:variable name="effectivity.match.arch">
       <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
@@ -231,12 +231,44 @@
         <xsl:with-param name="b" select="@arch" />
       </xsl:call-template>
     </xsl:variable>
-    <xsl:variable name="effectivity.attribute.audience" select="@audience" />
-    <xsl:variable name="effectivity.attribute.condition" select="@condition" />
-    <xsl:variable name="effectivity.attribute.conformance" select="@conformance" />
-    <xsl:variable name="effectivity.attribute.os" select="@os" />
 
-    <xsl:variable name="effectivity.attribute.outputformat">
+    <xsl:variable name="effectivity.match.audience">
+       <xsl:message>INFO (filterin): The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.audience" />
+        <xsl:with-param name="b" select="@audience" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.condition">
+       <xsl:message>INFO (filterin): The value of effectivity.condition as passed in is <xsl:value-of select="$effectivity.condition" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @condition as read from the XML file is <xsl:value-of select="@condition" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.condition" />
+        <xsl:with-param name="b" select="@condition" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.conformance">
+       <xsl:message>INFO (filterin): The value of effectivity.conformance as passed in is <xsl:value-of select="$effectivity.conformance" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @conformance as read from the XML file is <xsl:value-of select="@conformance" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.conformance" />
+        <xsl:with-param name="b" select="@conformance" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.os">
+       <xsl:message>INFO (filterin): The value of effectivity.os as passed in is <xsl:value-of select="$effectivity.os" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @os as read from the XML file is <xsl:value-of select="@os" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.os" />
+        <xsl:with-param name="b" select="@os" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.outputformat">
       <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
       <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
       <xsl:call-template name="cross.compare">
@@ -245,72 +277,112 @@
       </xsl:call-template>
     </xsl:variable>
 
-    <xsl:variable name="effectivity.attribute.revision" select="@revision" />
-    <xsl:variable name="effectivity.attribute.security" select="@security" />
-    <xsl:variable name="effectivity.attribute.userlevel" select="@userlevel" />
-    <xsl:variable name="effectivity.attribute.vendor" select="@vendor" />
-    <xsl:variable name="effectivity.attribute.wordsize" select="@wordsize" />
+    <xsl:variable name="effectivity.match.revision">
+       <xsl:message>INFO (filterin): The value of effectivity.revision as passed in is <xsl:value-of select="$effectivity.revision" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @revision as read from the XML file is <xsl:value-of select="@revision" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.revision" />
+        <xsl:with-param name="b" select="@revision" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.security">
+       <xsl:message>INFO (filterin): The value of effectivity.security as passed in is <xsl:value-of select="$effectivity.security" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @security as read from the XML file is <xsl:value-of select="@security" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.security" />
+        <xsl:with-param name="b" select="@security" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.userlevel">
+      <xsl:message>INFO (filterin): The value of effectivity.userlevel as passed in is <xsl:value-of select="$effectivity.userlevel" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @userlevel as read from the XML file is <xsl:value-of select="@userlevel" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.userlevel" />
+        <xsl:with-param name="b" select="@userlevel" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.vendor">
+      <xsl:message>INFO (filterin): The value of effectivity.vendor as passed in is <xsl:value-of select="$effectivity.vendor" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @vendor as read from the XML file is <xsl:value-of select="@vendor" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.vendor" />
+        <xsl:with-param name="b" select="@vendor" />
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:variable name="effectivity.match.wordsize">
+      <xsl:message>INFO (filterin): The value of effectivity.wordsize as passed in is <xsl:value-of select="$effectivity.wordsize" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @wordsize as read from the XML file is <xsl:value-of select="@wordsize" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.wordsize" />
+        <xsl:with-param name="b" select="@wordsize" />
+      </xsl:call-template>
+    </xsl:variable>
 
     <xsl:choose>
       <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.attribute.arch" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.audience = $effectivity.audience">
+
+      <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.attribute.audience" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.condition = $effectivity.condition">
+
+      <xsl:when test="$effectivity.match.condition != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.attribute.condition" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the condition attribute value is set to <xsl:value-of select="$effectivity.match.condition" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.conformance = $effectivity.conformance">
+
+      <xsl:when test="$effectivity.match.conformance != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.attribute.conformance" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the conformance attribute value is set to <xsl:value-of select="$effectivity.match.conformance" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.os = $effectivity.os">
+
+      <xsl:when test="$effectivity.match.os != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.attribute.os" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the os attribute value is set to <xsl:value-of select="$effectivity.match.os" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.outputformat = $effectivity.outputformat">
+
+      <xsl:when test="$effectivity.match.outputformat != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.attribute.outputformat" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the outputformat attribute value is set to <xsl:value-of select="$effectivity.match.outputformat" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.revision = $effectivity.revision">
+
+      <xsl:when test="$effectivity.match.revision != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.attribute.revision" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the revision attribute value is set to <xsl:value-of select="$effectivity.match.revision" />.</xsl:message> 
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.security = $effectivity.security">
+
+      <xsl:when test="$effectivity.match.security != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.attribute.security" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the security attribute value is set to <xsl:value-of select="$effectivity.match.security" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.userlevel = $effectivity.userlevel">
+
+      <xsl:when test="$effectivity.match.userlevel != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.attribute.userlevel" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the userlevel attribute value is set to <xsl:value-of select="$effectivity.match.userlevel" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.vendor = $effectivity.vendor">
+
+      <xsl:when test="$effectivity.match.vendor != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.attribute.vendor" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the vendor attribute value is set to <xsl:value-of select="$effectivity.match.vendor" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.wordsize = $effectivity.wordsize">
+
+      <xsl:when test="$effectivity.match.wordsize != ''">
         <xsl:text>include</xsl:text>
-        <!--
-        <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.attribute.wordsize" />.</xsl:message> -->
+        <xsl:message>INFO: including a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.match.wordsize" />.</xsl:message>
       </xsl:when>
+
       <xsl:otherwise>
         <xsl:text>exclude</xsl:text>
         <!-- <xsl:message>INFO: No modules or structures matched attributes for inclusion.</xsl:message> -->
       </xsl:otherwise>
+
     </xsl:choose>
 
   </xsl:template>

--- a/xsl/assembly/effectivity.xsl
+++ b/xsl/assembly/effectivity.xsl
@@ -7,6 +7,9 @@
   xmlns="http://docbook.org/ns/docbook"
   exclude-result-prefixes="exsl d xlink d"
   version="1.0">
+
+<xsl:include href="../profiling/profile-mode.xsl"/>
+<xsl:include href="../common/addns.xsl"/>
   
 <!-- NOTE: If a structure or module is filtered out due to a matching effectivity attribute, children of that structure or module cannot be filtered in using another effectivity attribute. -->
 
@@ -21,41 +24,79 @@
   <xsl:param name="effectivity.userlevel" />
   <xsl:param name="effectivity.vendor" />
   <xsl:param name="effectivity.wordsize" />
+  <xsl:param name="effectivity.separator" />
+
+  <xsl:param name="profile.arch" select="$effectivity.arch"/>
+  <xsl:param name="profile.audience" select="$effectivity.audience"/>
+  <xsl:param name="profile.condition" select="$effectivity.condition" />
+  <xsl:param name="profile.conformance" select="$effectivity.conformance"/>
+  <xsl:param name="profile.os" select="$effectivity.os"/>
+  <xsl:param name="profile.outputformat" select="$effectivity.outputformat"/>
+  <xsl:param name="profile.revision" select="$effectivity.revision"/>
+  <xsl:param name="profile.security" select="$effectivity.security"/>
+  <xsl:param name="profile.userlevel" select="$effectivity.userlevel"/>
+  <xsl:param name="profile.vendor" select="$effectivity.vendor"/>
+  <xsl:param name="profile.wordsize" select="$effectivity.wordsize"/>
+  <xsl:param name="profile.lang"/>
+  <xsl:param name="profile.revisionflag"/>
+  <xsl:param name="profile.role"/>
+  <xsl:param name="profile.status"/>
+  <xsl:param name="profile.attribute"/>
+  <xsl:param name="profile.value"/>
+  <xsl:param name="profile.separator" select="$effectivity.separator" />
+
+
 
   <xsl:template match="d:module[@resourceref] | d:structure[@resourceref]" mode="evaluate.effectivity">
     <xsl:apply-templates mode="evaluate.effectivity" />
   </xsl:template>
   
   <xsl:template match="d:filterout" mode="evaluate.effectivity">
+    <xsl:message>INFO: I'm inside the filterout template!</xsl:message>
+    
     <xsl:variable name="effectivity.match.arch">
+      <xsl:message>INFO: The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message>
       <xsl:call-template name="cross.compare">
-        <xsl:with-param name="a" select="effectivity.arch" />
+        <xsl:with-param name="a" select="$effectivity.arch" />
         <xsl:with-param name="b" select="@arch" />
       </xsl:call-template>
     </xsl:variable>
-    <xsl:variable name="effectivity.match.audience" select="@audience" />
-    <xsl:variable name="effectivity.match.condition" select="@condition" />
-    <xsl:variable name="effectivity.match.conformance" select="@conformance" />
-    <xsl:variable name="effectivity.match.os" select="@os" />
-    <xsl:variable name="effectivity.match.outputformat" select="@outputformat" />
-    <xsl:variable name="effectivity.match.revision" select="@revision" />
-    <xsl:variable name="effectivity.match.security" select="@security" />
-    <xsl:variable name="effectivity.match.userlevel" select="@userlevel" />
-    <xsl:variable name="effectivity.match.vendor" select="@vendor" />
-    <xsl:variable name="effectivity.match.wordsize" select="@wordsize" />
+    <xsl:message>INFO: The value of effectivity.match.arch is <xsl:value-of select="$effectivity.match.arch"/> ... </xsl:message>
+
+    <xsl:variable name="effectivity.match.audience">
+      <xsl:message>INFO: The value of effectivity.audience as passed in is <xsl:value-of select="$effectivity.audience" /> ... </xsl:message>
+      <xsl:message>INFO: The value of @audience as read from the XML file is <xsl:value-of select="@audience" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.audience" />
+        <xsl:with-param name="b" select="@audience" />
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="effectivity.attribute.condition" select="@condition" />
+    <xsl:variable name="effectivity.attribute.conformance" select="@conformance" />
+    <xsl:variable name="effectivity.attribute.os" select="@os" />
+    <xsl:variable name="effectivity.attribute.outputformat" select="@outputformat" />
+    <xsl:variable name="effectivity.attribute.revision" select="@revision" />
+    <xsl:variable name="effectivity.attribute.security" select="@security" />
+    <xsl:variable name="effectivity.attribute.userlevel" select="@userlevel" />
+    <xsl:variable name="effectivity.attribute.vendor" select="@vendor" />
+    <xsl:variable name="effectivity.attribute.wordsize" select="@wordsize" />
 
     <xsl:choose>
       <!-- <xsl:when test="$effectivity.attribute.arch = $effectivity.arch"> -->
-      <xsl:when test="effectivity.match.arch != ''">
+      <!-- <xsl:when test="effectivity.match.arch != '' "> -->
+      <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.attribute.arch" />.</xsl:message> -->
+        
+        <xsl:message>INFO: filtering out a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.match.arch" />.</xsl:message>
       </xsl:when>
-      <xsl:when test="$effectivity.attribute.audience = $effectivity.audience">
+
+      <xsl:when test="$effectivity.match.audience != ''">
         <xsl:text>exclude</xsl:text>
-        <!--
-        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.attribute.audience" />.</xsl:message> -->
+        
+        <xsl:message>INFO: filtering out a module or structure because the audience attribute value is set to <xsl:value-of select="$effectivity.match.audience" />.</xsl:message> -->
       </xsl:when>
+
       <xsl:when test="$effectivity.attribute.condition = $effectivity.condition">
         <xsl:text>exclude</xsl:text>
         <!--
@@ -102,7 +143,7 @@
         <xsl:message>INFO: filtering out a module or structure because the wordsize attribute value is set to <xsl:value-of select="$effectivity.attribute.wordsize" />.</xsl:message> -->
       </xsl:when>
       <xsl:otherwise>
-        <!-- <xsl:message>INFO: no filterout attributes matched.</xsl:message> -->
+        <xsl:message>INFO: no filterout attributes matched.</xsl:message>
       </xsl:otherwise>
     </xsl:choose>
 
@@ -110,13 +151,30 @@
   
   <!-- filterin logic -->
   <xsl:template match="d:filterin" mode="evaluate.effectivity">
+    <xsl:message>INFO: I'm inside the filterout template!</xsl:message>
 
-    <xsl:variable name="effectivity.attribute.arch" select="@arch" />
+    <xsl:variable name="effectivity.match.arch">
+      <xsl:message>INFO (filterin): The value of effectivity.arch as passed in is <xsl:value-of select="$effectivity.arch" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @arch as read from the XML file is <xsl:value-of select="@arch" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.arch" />
+        <xsl:with-param name="b" select="@arch" />
+      </xsl:call-template>
+    </xsl:variable>
     <xsl:variable name="effectivity.attribute.audience" select="@audience" />
     <xsl:variable name="effectivity.attribute.condition" select="@condition" />
     <xsl:variable name="effectivity.attribute.conformance" select="@conformance" />
     <xsl:variable name="effectivity.attribute.os" select="@os" />
-    <xsl:variable name="effectivity.attribute.outputformat" select="@outputformat" />
+
+    <xsl:variable name="effectivity.attribute.outputformat">
+      <xsl:message>INFO (filterin): The value of effectivity.outputformat as passed in is <xsl:value-of select="$effectivity.outputformat" /> ... </xsl:message>
+      <xsl:message>INFO (filterin): The value of @outputformat as read from the XML file is <xsl:value-of select="@outputformat" /> ... </xsl:message>
+      <xsl:call-template name="cross.compare">
+        <xsl:with-param name="a" select="$effectivity.outputformat" />
+        <xsl:with-param name="b" select="@outputformat" />
+      </xsl:call-template>
+    </xsl:variable>
+
     <xsl:variable name="effectivity.attribute.revision" select="@revision" />
     <xsl:variable name="effectivity.attribute.security" select="@security" />
     <xsl:variable name="effectivity.attribute.userlevel" select="@userlevel" />
@@ -124,7 +182,7 @@
     <xsl:variable name="effectivity.attribute.wordsize" select="@wordsize" />
 
     <xsl:choose>
-      <xsl:when test="$effectivity.attribute.arch = $effectivity.arch">
+      <xsl:when test="$effectivity.match.arch != ''">
         <xsl:text>include</xsl:text>
         <!--
         <xsl:message>INFO: including a module or structure because the arch attribute value is set to <xsl:value-of select="$effectivity.attribute.arch" />.</xsl:message> -->
@@ -186,5 +244,33 @@
     </xsl:choose>
 
   </xsl:template>
+
+
+  <!-- Returns non-empty string if list in $b contains one ore more values from list $a --> 
+ <!-- Commenting out the copied cross.compare template 
+<xsl:template name="cross.compare">
+
+  <xsl:param name="a"/>
+  <xsl:param name="b"/>
+  <xsl:param name="sep" select="$profile.separator"/>
+  <xsl:variable name="head" select="substring-before(concat($a, $sep), $sep)"/>
+  <xsl:variable name="tail" select="substring-after($a, $sep)"/> 
+-->
+<!-- <xsl:message> -->
+<!-- a="<xsl:value-of select="$a"/>" -->
+<!-- a="<xsl:value-of select="normalize-space($a)"/>" -->
+<!-- head="<xsl:value-of select="$head"/>" -->
+<!-- tail="<xsl:value-of select="$tail"/>" -->
+<!-- </xsl:message> -->
+<!--
+  <xsl:message>INFO: My profile separator character is <xsl:value-of select="$profile.separator"/> ...</xsl:message>
+  <xsl:if test="contains(concat($sep, $b, $sep), concat($sep, $head, $sep)) or normalize-space($a) = '' ">1</xsl:if>
+  <xsl:if test="$tail">
+    <xsl:call-template name="cross.compare">
+      <xsl:with-param name="a" select="$tail"/>
+      <xsl:with-param name="b" select="$b"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template> -->
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR updates the `effectivity.xsl` stylesheet with logic required to support `filterin` and `filterout` elements whose attributes may have multiple values separated using a user-defined delimiter. 

A module or structure containing a `filterout` element whose effectivity attribute(s) has one or more values separated by a user-defined delimiter (e.g. a semicolon or a pipe), the processor only excludes the module or structure if least one effectivity attribute value exactly matches the effectivity parameter value passed to the stylesheet.  

A module or structure containing a `filterin` element whose effectivity attribute(s) has one or more values separated by a user-defined delimiter (e.g. a semicolon or a pipe), the processor only includes the modules if at least one effectivity attribute value exactly matches the effectivity parameter value passed to the stylesheet. 